### PR TITLE
Correctly set previous navigation service to page model

### DIFF
--- a/src/FreshMvvm.Maui/PageModelCoreMethods.cs
+++ b/src/FreshMvvm.Maui/PageModelCoreMethods.cs
@@ -84,7 +84,7 @@ namespace FreshMvvm.Maui
             pageModel.PreviousPageModel = _currentPageModel; //This is the previous page model because it's push to a new one, and this is current
             pageModel.CurrentNavigationService = _currentPageModel.CurrentNavigationService;
 
-            if (pageModel.PreviousNavigationService != null)
+            if (_currentPageModel.PreviousNavigationService != null)
                 pageModel.PreviousNavigationService = _currentPageModel.PreviousNavigationService;
 
             if (page is FreshMasterDetailNavigationContainer) 


### PR DESCRIPTION
Small fix - encountered when using nested navigation services (i.e. a FreshNavigationService within FreshTabbedNavigationContainer). 

When popping to the parent navigation service the previous navigation service was null causing a crash.

Should close out #10.